### PR TITLE
options {end: true} to stream.pipe are not necessary

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,10 +43,10 @@ function PicoProxy(options) {
       }
 
       res.writeHead(serverRes.statusCode, serverRes.headers);
-      serverRes.pipe(res, { end: true });
+      serverRes.pipe(res);
     }.bind(this));
 
-    req.pipe(request, { end: true });
+    req.pipe(request);
   }.bind(this));
 
   return this;


### PR DESCRIPTION
Hi,

just small change to remove unnecessary options.
https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options

Besides that, thanks ! This is exactly the module i m looking for : )
