### PR TITLE
do not write head twice on non options requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,11 +81,8 @@ PicoProxy.prototype.close = function () {
 
 PicoProxy.prototype.createServer = function (cb) {
   return protocol[this._protocol].createServer(function (req, res) {
-    if (this._cors) {
+    if (this._cors && req.method.match(/options/i)) {
       res.writeHead(200, corsHeaders(this._corsOverrides));
-    }
-
-    if (this._cors && req.method.toLowerCase() === 'options') {
       return res.end();
     }
 


### PR DESCRIPTION
Hi,

I found a problem when writeHead was called twice.

The origin server response is :

``` json
{
  "audiofilters":{
    "filter_0":""
  },
  "currentplid":-1,
  "time":0,
  "subtitledelay":0,
  "equalizer":[],
  "apiversion":3,
  "videoeffects":{
    "gamma":1.0,
    "hue":0.0,
    "brightness":1.0,
    "saturation":1.0,
    "contrast":1.0
  },
  "rate":1,
  "repeat":false,
  "volume":0.0,
  "fullscreen":0,
  "random":false,
  "version":"2.2.2 Weatherwax",
  "audiodelay":0,
  "length":0,
  "position":0,
  "loop":false,
  "state":"stopped"
}
```

The proxified response would become :

```
1c3
{
  "subtitledelay":0,
  "random":false,
  "loop":false,
  "audiofilters":{
    "filter_0":""
  },
  "state":"stopped",
  "version":"2.2.2 Weatherwax",
  "fullscreen":0,
  "equalizer":[],
  "length":0,
  "volume":0.0,
  "apiversion":3,
  "audiodelay":0,
  "rate":1,
  "videoeffects":{
    "brightness":1.0,
    "hue":0.0,
    "saturation":1.0,
    "gamma":1.0,
    "contrast":1.0
  },
  "repeat":false,
  "currentplid":-1,
  "position":0,
  "time
```

This change fixes this problem.
